### PR TITLE
Remove blog article tags

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,18 +1,8 @@
-import { cache } from "react";
-import { notFound } from "next/navigation";
-import { MDXRemote } from "next-mdx-remote/rsc";
-import { getAllPostSlugs, getPostBySlug } from "@/lib/blog";
-import { remarkPlugins, rehypePlugins } from "@/lib/mdx-options";
-import { extractHeadings } from "@/lib/extract-headings";
-import { mdxComponents } from "@/components/mdx/MDXComponents";
-import TableOfContents from "@/components/TableOfContents";
-import ReadingProgress from "@/components/ReadingProgress";
-import { formatDate } from "@/lib/utils";
-import Link from "next/link";
-import SubscribeForm from "@/components/SubscribeForm";
 import type { Metadata } from "next";
-
-const getCachedPost = cache((slug: string) => getPostBySlug(slug));
+import BlogPostPageContent, {
+  getBlogPostMetadata,
+} from "@/components/blog/BlogPostPageContent";
+import { getAllPostSlugs } from "@/lib/blog";
 
 interface Props {
   params: { slug: string };
@@ -23,94 +13,9 @@ export function generateStaticParams() {
 }
 
 export function generateMetadata({ params }: Props): Metadata {
-  try {
-    const post = getCachedPost(params.slug);
-    const metadata: Metadata = {
-      title: `${post.title} — Bassim Eledath`,
-      description: post.description,
-    };
-    if (post.thumbnail) {
-      metadata.openGraph = {
-        images: [{ url: post.thumbnail }],
-      };
-      metadata.twitter = {
-        card: "summary_large_image",
-        images: [post.thumbnail],
-      };
-    }
-    return metadata;
-  } catch {
-    return { title: "Post Not Found" };
-  }
+  return getBlogPostMetadata(params.slug);
 }
 
 export default function BlogPostPage({ params }: Props) {
-  let post;
-  try {
-    post = getCachedPost(params.slug);
-  } catch {
-    notFound();
-  }
-
-  const headings = extractHeadings(post.content);
-  const showModified =
-    post.modified &&
-    post.published &&
-    post.modified.slice(0, 10) !== post.published.slice(0, 10);
-
-  return (
-    <div className="relative py-16 toc:flex toc:gap-16 toc:justify-center">
-      <ReadingProgress />
-      <article className="mx-auto max-w-[72ch] toc:mx-0">
-        <Link
-          href="/blog"
-          className="mb-8 inline-flex items-center gap-1 text-sm text-muted transition-colors hover:text-foreground"
-        >
-          &larr; All posts
-        </Link>
-        <header className="mb-10">
-          <h1 className="font-serif text-3xl font-medium tracking-tight text-foreground sm:text-4xl">
-            {post.title}
-          </h1>
-          <div className="mt-3 flex flex-wrap gap-x-4 text-sm text-muted">
-            <time>{formatDate(post.published)}</time>
-            {showModified && (
-              <span className="text-muted/60">
-                Updated {formatDate(post.modified)}
-              </span>
-            )}
-          </div>
-          {post.tags.length > 0 && (
-            <div className="mt-4 flex flex-wrap gap-2">
-              {post.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full bg-[rgb(var(--tag-bg))] px-2.5 py-0.5 text-xs text-muted"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-        </header>
-
-        <div className="prose prose-lg max-w-none">
-          <MDXRemote
-            source={post.content}
-            components={mdxComponents}
-            options={{
-              mdxOptions: {
-                remarkPlugins: remarkPlugins as never,
-                rehypePlugins: rehypePlugins as never,
-              },
-            }}
-          />
-        </div>
-
-        <SubscribeForm />
-      </article>
-
-      <TableOfContents headings={headings} />
-    </div>
-  );
+  return <BlogPostPageContent slug={params.slug} />;
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { FiArrowUpRight } from "react-icons/fi";
-import { getAllPosts, getExcerpt } from "@/lib/blog";
+import { getAllPosts, getExcerpt, getPostPath } from "@/lib/blog";
 import { formatDate } from "@/lib/utils";
 
 export default function BlogPage() {
@@ -18,23 +18,11 @@ export default function BlogPage() {
         {posts.map((post, i) => (
           <Link
             key={post.slug}
-            href={`/blog/${post.slug}`}
+            href={getPostPath(post.slug)}
             className="animate-fade-up group flex flex-col rounded-lg border border-border p-5 transition-all duration-200 hover:border-muted hover:-translate-y-0.5 hover:shadow-sm"
             style={{ animationDelay: `${(i + 1) * 80}ms` }}
           >
-            <div className="flex items-center justify-between text-xs text-muted">
-              <div className="flex gap-1.5">
-                {post.tags.length > 0
-                  ? post.tags.slice(0, 2).map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full bg-[rgb(var(--tag-bg))] px-2 py-0.5 text-xs text-muted"
-                      >
-                        {tag}
-                      </span>
-                    ))
-                  : <span className="rounded-full bg-[rgb(var(--tag-bg))] px-2 py-0.5 text-xs text-muted">Writing</span>}
-              </div>
+            <div className="flex justify-end text-muted">
               <FiArrowUpRight
                 size={14}
                 className="opacity-0 transition-opacity group-hover:opacity-100"

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,4 +1,4 @@
-import { getAllPosts, getExcerpt } from "@/lib/blog";
+import { getAllPosts, getExcerpt, getPostPath } from "@/lib/blog";
 
 export const dynamic = "force-dynamic";
 
@@ -19,15 +19,12 @@ export async function GET() {
 
   const items = posts
     .map((post) => {
-      const url = `${SITE_URL}/blog/${post.slug}`;
+      const url = `${SITE_URL}${getPostPath(post.slug)}`;
       const pubDate = new Date(post.published).toUTCString();
       const description = escapeXml(
         post.description || getExcerpt(post.content)
       );
       const title = escapeXml(post.title);
-      const categories = post.tags
-        .map((tag) => `<category>${escapeXml(tag)}</category>`)
-        .join("\n        ");
 
       return `
     <item>
@@ -36,7 +33,6 @@ export async function GET() {
       <guid isPermaLink="true">${escapeXml(url)}</guid>
       <pubDate>${pubDate}</pubDate>
       <description>${description}</description>
-      ${categories}
     </item>`;
     })
     .join("");

--- a/app/tokenmaxxing/page.tsx
+++ b/app/tokenmaxxing/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import BlogPostPageContent, {
+  getBlogPostMetadata,
+} from "@/components/blog/BlogPostPageContent";
+
+const SLUG = "tokenmaxxing";
+
+export function generateMetadata(): Metadata {
+  return getBlogPostMetadata(SLUG);
+}
+
+export default function TokenmaxxingPage() {
+  return <BlogPostPageContent slug={SLUG} />;
+}

--- a/components/blog/BlogPostPageContent.tsx
+++ b/components/blog/BlogPostPageContent.tsx
@@ -1,0 +1,96 @@
+import { cache } from "react";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import Link from "next/link";
+import type { Metadata } from "next";
+import ReadingProgress from "@/components/ReadingProgress";
+import SubscribeForm from "@/components/SubscribeForm";
+import TableOfContents from "@/components/TableOfContents";
+import { mdxComponents } from "@/components/mdx/MDXComponents";
+import { extractHeadings } from "@/lib/extract-headings";
+import { getPostBySlug } from "@/lib/blog";
+import { remarkPlugins, rehypePlugins } from "@/lib/mdx-options";
+import { formatDate } from "@/lib/utils";
+
+const getCachedPost = cache((slug: string) => getPostBySlug(slug));
+
+export function getBlogPostMetadata(slug: string): Metadata {
+  try {
+    const post = getCachedPost(slug);
+    const metadata: Metadata = {
+      title: `${post.title} — Bassim Eledath`,
+      description: post.description,
+    };
+    if (post.thumbnail) {
+      metadata.openGraph = {
+        images: [{ url: post.thumbnail }],
+      };
+      metadata.twitter = {
+        card: "summary_large_image",
+        images: [post.thumbnail],
+      };
+    }
+    return metadata;
+  } catch {
+    return { title: "Post Not Found" };
+  }
+}
+
+export default function BlogPostPageContent({ slug }: { slug: string }) {
+  let post;
+  try {
+    post = getCachedPost(slug);
+  } catch {
+    notFound();
+  }
+
+  const headings = extractHeadings(post.content);
+  const showModified =
+    post.modified &&
+    post.published &&
+    post.modified.slice(0, 10) !== post.published.slice(0, 10);
+
+  return (
+    <div className="relative py-16 toc:flex toc:gap-16 toc:justify-center">
+      <ReadingProgress />
+      <article className="mx-auto max-w-[72ch] toc:mx-0">
+        <Link
+          href="/blog"
+          className="mb-8 inline-flex items-center gap-1 text-sm text-muted transition-colors hover:text-foreground"
+        >
+          &larr; All posts
+        </Link>
+        <header className="mb-10">
+          <h1 className="font-serif text-3xl font-medium tracking-tight text-foreground sm:text-4xl">
+            {post.title}
+          </h1>
+          <div className="mt-3 flex flex-wrap gap-x-4 text-sm text-muted">
+            <time>{formatDate(post.published)}</time>
+            {showModified && (
+              <span className="text-muted/60">
+                Updated {formatDate(post.modified)}
+              </span>
+            )}
+          </div>
+        </header>
+
+        <div className="prose prose-lg max-w-none">
+          <MDXRemote
+            source={post.content}
+            components={mdxComponents}
+            options={{
+              mdxOptions: {
+                remarkPlugins: remarkPlugins as never,
+                rehypePlugins: rehypePlugins as never,
+              },
+            }}
+          />
+        </div>
+
+        <SubscribeForm />
+      </article>
+
+      <TableOfContents headings={headings} />
+    </div>
+  );
+}

--- a/content/blog/dispatch.mdx
+++ b/content/blog/dispatch.mdx
@@ -2,7 +2,6 @@
 title: "10x Your Claude Code Window Size with Dispatch"
 description: "Your Claude Code session has a fixed context window. Dispatch multiplies it by turning your session into a lightweight orchestrator while dedicated workers each run with their own full context."
 thumbnail: /images/blog/dispatch-before-after.jpg
-tags: ["AI", "Claude Code", "Developer Tools"]
 published: "2026-02-23T07:44:46-08:00"
 modified: "2026-02-24T23:46:01-08:00"
 ---

--- a/content/blog/game-factory.mdx
+++ b/content/blog/game-factory.mdx
@@ -3,7 +3,6 @@ title: "An Autonomous Game Factory with Claude Code and a $24 VPS"
 description: "Anyone can prompt 'make a flappy bird game.' Making hundreds of unique, styled,
 working games fully autonomously is a different problem entirely."
 thumbnail: /images/blog/game-factory-grid-5x5.png
-tags: ["AI", "Claude Code", "Autonomous Agents", "Game Development"]
 published: "2026-04-01T00:19:02-07:00"
 modified: "2026-04-01T00:42:57-07:00"
 ---

--- a/content/blog/invariant-engineering.mdx
+++ b/content/blog/invariant-engineering.mdx
@@ -2,7 +2,6 @@
 title: "Invariant Engineering: Why Your AI Agent Is Either Broken or Boring"
 description: "Deciding what your AI system is and isn't allowed to vary. Most teams get this wrong in one of two directions."
 thumbnail: /images/blog/invariant-engineering.png
-tags: ["AI", "Agentic Engineering", "Developer Tools"]
 published: "2026-04-12T18:01:52-07:00"
 modified: "2026-04-12T22:39:29-07:00"
 ---

--- a/content/blog/levels-of-agentic-engineering.mdx
+++ b/content/blog/levels-of-agentic-engineering.mdx
@@ -2,7 +2,6 @@
 title: "The 8 Levels of Agentic Engineering"
 description: "AI's coding ability is outpacing our ability to wield it effectively. That gap closes in levels — 8 of them. Here's the progression from tab complete to autonomous agent teams."
 thumbnail: /images/blog/agentic_thumbnail.jpg
-tags: ["AI", "Agentic Engineering", "Developer Tools"]
 published: "2026-03-10T01:31:01-07:00"
 modified: "2026-03-11T22:06:21-07:00"
 ---

--- a/content/blog/tokenmaxxing.mdx
+++ b/content/blog/tokenmaxxing.mdx
@@ -1,7 +1,6 @@
 ---
 title: "How to Tokenmaxx"
 description: "Tokenmaxxing is fine if the tokens go toward planning, verification, context, feedback loops, and agent-friendly output. It is a terrible proxy for AI competence on its own."
-tags: ["AI", "LLMs", "Work"]
 published: "2026-05-14T02:00:37-07:00"
 modified: "2026-05-20T00:00:00-07:00"
 ---

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -9,7 +9,6 @@ export interface BlogPost {
   title: string;
   description: string;
   thumbnail?: string;
-  tags: string[];
   published: string;
   modified: string;
   content: string;
@@ -47,11 +46,14 @@ export function getPostBySlug(slug: string): BlogPost {
     title: data.title || slug,
     description: data.description || "",
     thumbnail: data.thumbnail,
-    tags: data.tags || [],
     published,
     modified,
     content,
   };
+}
+
+export function getPostPath(slug: string): string {
+  return slug === "tokenmaxxing" ? "/tokenmaxxing" : `/blog/${slug}`;
 }
 
 /** Extract the first plain-text snippet from MDX content. */

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,12 +4,22 @@ const nextConfig = {
     return [
       {
         source: "/blog/traits-of-ai-native-people",
-        destination: "/blog/token-count-is-a-terrible-proxy-for-ai-competence",
+        destination: "/tokenmaxxing",
         permanent: true,
       },
       {
         source: "/blog/token-count-is-a-bad-proxy-for-ai-native-work",
-        destination: "/blog/token-count-is-a-terrible-proxy-for-ai-competence",
+        destination: "/tokenmaxxing",
+        permanent: true,
+      },
+      {
+        source: "/blog/token-count-is-a-terrible-proxy-for-ai-competence",
+        destination: "/tokenmaxxing",
+        permanent: true,
+      },
+      {
+        source: "/blog/tokenmaxxing",
+        destination: "/tokenmaxxing",
         permanent: true,
       },
     ];


### PR DESCRIPTION
## Summary
- remove blog article tag frontmatter and tag rendering
- add root-level /tokenmaxxing page for the tokenmaxxing article
- redirect older AI-native and long token-count URLs to /tokenmaxxing
- update blog index and RSS feed to use the canonical post path

## Validation
- npm run build